### PR TITLE
Update to angular2 beta 11 + do not force CSS/HTML loading with RAW loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "live-server": "^0.9.2",
     "typescript": "^1.7.9"
   },
-  "peerDependencies": {
-      "raw-loader": "^0.5.1"
-  },
   "engines": {
     "node": ">=5.4"
   }

--- a/package.json
+++ b/package.json
@@ -17,21 +17,23 @@
     "url": "https://github.com/ForNeVeR/mydatepicker.git"
   },
   "dependencies": {
-    "angular2": "^2.0.0-beta.8",
-    "systemjs": "0.19.6",
+    "angular2": "^2.0.0-beta.11",
+    "systemjs": "0.19.24",
     "es6-promise": "^3.0.2",
-    "es6-shim": "^0.33.3",
+    "es6-shim": "^0.35.0",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.2",
-    "zone.js": "0.5.15"
+    "zone.js": "0.6.4"
   },
   "devDependencies": {
-    "concurrently": "^1.0.0",
-    "live-server": "^0.8.2",
-    "typescript": "^1.7.3"
+    "concurrently": "^2.0.0",
+    "live-server": "^0.9.2",
+    "typescript": "^1.7.9"
   },
   "peerDependencies": {
       "raw-loader": "^0.5.1"
   },
-  "engine": "node >= 0.10"
+  "engines": {
+    "node": ">=5.4"
+  }
 }

--- a/src/app/mydatepicker.ts
+++ b/src/app/mydatepicker.ts
@@ -2,15 +2,16 @@ import {Component, View, Input, Output, EventEmitter, OnInit, OnChanges, SimpleC
 import {NgIf, NgFor, NgClass, NgStyle, NgModel} from 'angular2/common';
 import {MyDate, MyMonth} from './interfaces';
 
-declare var require: any;
+const styles: string = require('./css/mydatepicker.css');
+const template: string = require('./template/mydatepicker.html');
 
 @Component({
     selector: 'my-date-picker'
 })
 @View({
-    template: require('raw!./template/mydatepicker.html'),
-    styles: [require('raw!./css/mydatepicker.css')],
-    directives: [NgIf, NgFor, NgClass, NgStyle]
+    directives: [NgIf, NgFor, NgClass, NgStyle],
+    styles: [styles],
+    template
 })
 
 export class MyDatePicker implements OnInit, OnChanges {

--- a/src/app/mydatepicker.ts
+++ b/src/app/mydatepicker.ts
@@ -1,14 +1,14 @@
-import {Component, View, Input, Output, EventEmitter, OnInit, OnChanges, SimpleChange, ElementRef} from 'angular2/core';
+import {Component, Input, Output, EventEmitter, OnInit, OnChanges, SimpleChange, ElementRef} from 'angular2/core';
 import {NgIf, NgFor, NgClass, NgStyle, NgModel} from 'angular2/common';
 import {MyDate, MyMonth} from './interfaces';
+
+declare var require: any;
 
 const styles: string = require('./css/mydatepicker.css');
 const template: string = require('./template/mydatepicker.html');
 
 @Component({
-    selector: 'my-date-picker'
-})
-@View({
+    selector: 'my-date-picker',
     directives: [NgIf, NgFor, NgClass, NgStyle],
     styles: [styles],
     template


### PR DESCRIPTION
Angular 2 beta 11 changes (put @View stuff inside @Component) + do not force using raw-loader for CSS/HTML files.

Which loader would be used to require which external dependency should be defined in Webpack config, for example I have the following config in use:

`module.exports = {
    module: {
        loaders: [
            {test: /\.ts$/, exclude: [/\.spec\.ts$/], loader: 'ts'},
            {test: /\.css$/, loader: 'raw'},
            {test: /\.html$/, loader: 'raw'},
            {test: /\.json$/, loader: 'json'}
        ]
}`

I would later probably want to use some other loader for HTML and CSS, for example for tests and else.