### PR TITLE
add locale input property

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Bind to an object containing replacements for any of the following defaults:
 #### width
   `'100%'`
 
+### locale
+A two-letter ISO 639-1 language code can be provided as shorthand for several of
+the options listed above. Currently supported languages: ja.
+
 ### selDate
 Provide the initially chosen date that will display both in the text input field
 and provide the default for the popped-up datepicker.


### PR DESCRIPTION
To facilitate internationalization, this PR provides a "locale" input property. Additional localizers can add options subsets to the private `_locales` property using the existing Japanese example as a template. Apologies for also incorporating an arguably unrelated bugfix to `_parseDate` that makes things more robust in the case where options are not provided. I did not notice this problem until I was able to stop using `options` to make my datepicker appear in Japanese using just this locale feature.