### PR TITLE
Add in validator support for "disableUntil" and "disableSince" 

### DIFF
--- a/src/my-date-picker/my-date-picker.component.spec.ts
+++ b/src/my-date-picker/my-date-picker.component.spec.ts
@@ -761,6 +761,89 @@ describe('MyDatePicker', () => {
         invaliddate = getElement('.invaliddate');
         expect(invaliddate).toBe(null);
     });
+    
+    it('options - disableUntil and disableSince date validation', ()=> {
+        comp.options = {
+            indicateInvalidDate: true, 
+            dateFormat: 'dd.mm.yyyy', 
+            disableUntil:{year: 2016, month: 11, day: 10}
+        }
+        
+        comp.parseOptions();
+        
+        comp.userDateInput({target:{value:'01.01.2015'}});
+        fixture.detectChanges();
+        let invaliddate = getElement('.invaliddate');
+        expect(invaliddate).not.toBe(null);
+        
+        comp.userDateInput({target:{value:'01.10.2016'}});
+        fixture.detectChanges();
+        invaliddate = getElement('.invaliddate');
+        expect(invaliddate).not.toBe(null);
+        
+        comp.userDateInput({target:{value:'10.11.2016'}});
+        fixture.detectChanges();
+        invaliddate = getElement('.invaliddate');
+        expect(invaliddate).not.toBe(null);
+        
+        comp.userDateInput({target:{value:'01.01.2017'}});
+        fixture.detectChanges();
+        invaliddate = getElement('.invaliddate');
+        expect(invaliddate).toBe(null);
+        
+        comp.userDateInput({target:{value:'11.11.2016'}});
+        fixture.detectChanges();
+        invaliddate = getElement('.invaliddate');
+        expect(invaliddate).toBe(null);
+        
+        comp.options = {
+            indicateInvalidDate: true, 
+            dateFormat: 'dd.mm.yyyy', 
+            disableSince:{year: 2016, month: 11, day: 10},
+            disableUntil:{year: 0, month: 0, day: 0}
+        }
+        comp.parseOptions();
+        
+        comp.userDateInput({target:{value:'01.01.2017'}});
+        fixture.detectChanges();
+        invaliddate = getElement('.invaliddate');
+        expect(invaliddate).not.toBe(null);
+        
+        comp.userDateInput({target:{value:'01.12.2016'}});
+        fixture.detectChanges();
+        invaliddate = getElement('.invaliddate');
+        expect(invaliddate).not.toBe(null);
+        
+        comp.userDateInput({target:{value:'10.11.2016'}});
+        fixture.detectChanges();
+        invaliddate = getElement('.invaliddate');
+        expect(invaliddate).not.toBe(null);
+        
+        comp.userDateInput({target:{value:'01.01.2015'}});
+        fixture.detectChanges();
+        invaliddate = getElement('.invaliddate');
+        expect(invaliddate).toBe(null);
+        
+        comp.userDateInput({target:{value:'09.11.2016'}});
+        fixture.detectChanges();
+        invaliddate = getElement('.invaliddate');
+        expect(invaliddate).toBe(null);
+        
+        comp.options = {
+            indicateInvalidDate: true, 
+            dateFormat: 'dd.mm.yyyy', 
+            disableSince:{year: 0, month: 0, day: 0},
+            disableUntil:{year: 0, month: 0, day: 0}
+        }
+        comp.parseOptions();
+        
+        comp.userDateInput({target:{value:'20.11.2016'}});
+        fixture.detectChanges();
+        invaliddate = getElement('.invaliddate');
+        expect(invaliddate).toBe(null);
+        
+        
+    });
 
     it('options - show date format in placeholder', () => {
         comp.selectedMonth = {monthTxt: '', monthNbr: 10, year: 2016};

--- a/src/my-date-picker/my-date-picker.component.ts
+++ b/src/my-date-picker/my-date-picker.component.ts
@@ -136,7 +136,7 @@ export class MyDatePicker implements OnChanges {
             this.removeBtnClicked();
         }
         else {
-            let date:IMyDate = this.validatorService.isDateValid(event.target.value, this.dateFormat, this.minYear, this.maxYear);
+            let date:IMyDate = this.validatorService.isDateValid(event.target.value, this.dateFormat, this.minYear, this.maxYear, this.disableUntil, this.disableSince);
             if(date.day !== 0 && date.month !== 0 && date.year !== 0) {
                 this.selectDate({ day: date.day, month: date.month, year: date.year });
             }

--- a/src/my-date-picker/services/my-date-picker.validator.service.ts
+++ b/src/my-date-picker/services/my-date-picker.validator.service.ts
@@ -5,7 +5,7 @@ import {IMyMonthLabels} from '../interfaces/my-month-labels.interface';
 @Injectable()
 export class ValidatorService {
 
-    isDateValid(date:string, dateFormat:string, minYear:number, maxYear:number): IMyDate {
+    isDateValid(date:string, dateFormat:string, minYear:number, maxYear:number, disableUntil:IMyDate, disableSince:IMyDate): IMyDate {
         let daysInMonth:Array<number> = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
         let returnDate:IMyDate = {day: 0, month: 0, year: 0};
@@ -36,6 +36,39 @@ export class ValidatorService {
 
             if(year < minYear || year > maxYear || month < 1 || month > 12) {
                 return returnDate;
+            }
+            
+            if(disableUntil.day > 0 && disableUntil.month > 0 && disableUntil.year > 0){
+                //disableUntil is set
+                //caller assumes risk of invalid day/month/year being provided
+                if(year < disableUntil.year){
+                    return returnDate;
+                }
+                if(year === disableUntil.year){
+                    if(month < disableUntil.month){
+                        return returnDate;
+                    }
+                    if (month === disableUntil.month && day <= disableUntil.day){
+                        return returnDate;
+                    }
+                }
+                
+            }
+            
+            if (disableSince.day > 0 && disableSince.month > 0 && disableSince.year > 0){
+                //disableSince is set
+                //caller assumes risk of invalid day/month/year being provided
+                if(year > disableSince.year){
+                    return returnDate;
+                }
+                if(year === disableSince.year){
+                    if(month > disableSince.month){
+                        return returnDate;
+                    }
+                    if(month === disableSince.month && day >= disableSince.day){
+                        return returnDate;
+                    }
+                }
             }
 
             if(year % 400 === 0 || (year % 100 !== 0 && year % 4 === 0)) {


### PR DESCRIPTION
As a side note, I'm not sure if it's a Windows related bug or not, but in tests if you expect a result from `getElement()` to be `null` , and it isn't (it returned a debugElement), it causes phantomjs to quickly eat up all its available RAM and crash.