### PR TITLE
Adding index signature to IMyOptions

### DIFF
--- a/src/my-date-picker/interfaces/my-options.interface.ts
+++ b/src/my-date-picker/interfaces/my-options.interface.ts
@@ -27,4 +27,5 @@ export interface IMyOptions {
     minYear?: number;
     maxYear?: number;
     componentDisabled?: boolean;
+    [key: string]: any;
 }


### PR DESCRIPTION
Compiling typescript using gulp in a project with mydatepicker imported gives the following error:

.../mydatepicker/src/my-date-picker/my-date-picker.component.ts(93,13): error TS7017: Index signature of object type implicitly has an 'any' type.
.../mydatepicker/src/my-date-picker/my-date-picker.component.ts(93,42): error TS7017: Index signature of object type implicitly has an 'any' type.
.../mydatepicker/src/my-date-picker/my-date-picker.component.ts(100,17): error TS7017: Index signature of object type implicitly has an 'any' type.

Fixed by adding an index signature to IMyOptions