### PR TITLE
Specify a custom placeholder for input

### DIFF
--- a/src/my-date-picker/interfaces/my-options.interface.ts
+++ b/src/my-date-picker/interfaces/my-options.interface.ts
@@ -22,6 +22,7 @@ export interface IMyOptions {
     alignSelectorRight?: boolean;
     indicateInvalidDate?: boolean;
     showDateFormatPlaceholder?: boolean;
+    placeholder?: string;
     editableDateField?: boolean;
     editableMonthAndYear?: boolean;
     minYear?: number;

--- a/src/my-date-picker/my-date-picker.component.html
+++ b/src/my-date-picker/my-date-picker.component.html
@@ -1,6 +1,6 @@
 <div class="mydp" [ngStyle]="{'width': opts.width, 'border': opts.inline ? 'none' : null}">
     <div class="selectiongroup" *ngIf="!opts.inline">
-        <input type="text" class="selection" aria-label="Calendar input field" [attr.maxlength]="opts.dateFormat.length" [ngClass]="{'invaliddate': invalidDate&&opts.indicateInvalidDate}" placeholder="{{opts.showDateFormatPlaceholder?opts.dateFormat:''}}"
+        <input type="text" class="selection" aria-label="Calendar input field" [attr.maxlength]="opts.dateFormat.length" [ngClass]="{'invaliddate': invalidDate&&opts.indicateInvalidDate}" placeholder="{{opts.showDateFormatPlaceholder?opts.dateFormat:opts.placeholder}}"
                 [ngStyle]="{'height': opts.height, 'line-height': opts.height, 'font-size': opts.selectionTxtFontSize, 'border': 'none', 'padding-right': selectionDayTxt.length>0 ? '60px' : '30px'}"
                 (keyup)="userDateInput($event)" [value]="selectionDayTxt" [disabled]="opts.componentDisabled" [readonly]="!opts.editableDateField">
         <span class="selbtngroup" [style.height]="opts.height">

--- a/src/my-date-picker/my-date-picker.component.ts
+++ b/src/my-date-picker/my-date-picker.component.ts
@@ -68,6 +68,7 @@ export class MyDatePicker implements OnChanges {
         alignSelectorRight: <boolean> false,
         indicateInvalidDate: <boolean> true,
         showDateFormatPlaceholder: <boolean> false,
+        placeholder: <string> '',
         editableDateField: <boolean> true,
         editableMonthAndYear: <boolean> true,
         minYear: <number> 1000,


### PR DESCRIPTION
It's nice to be able to specify a custom placeholder for input, in my case i need to put "Check in" and "Check out" placeholders to not break the form style (no labels but placeholder to identify each input)