### PR TITLE
feat(locales): change italian separator & add Switzerland italian

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Value of the __options__ attribute is a javascript object. It can contain the fo
 
 An ISO 639-1 language code can be provided as shorthand for several of the options listed above.
 Currently supported languages: __en__, __fr__, __ja__, __fi__, __es__, __hu__, __sv__, __nl__, __ru__, __no__, __tr__,
-__pt-br__, __de__, __it__, __pl__, __my__, __sk__ and __sl__. If the __locale__ attribute is used it overrides dayLabels, monthLabels, dateFormat, todayBtnTxt,
+__pt-br__, __de__, __it__, __it-ch__, __pl__, __my__, __sk__ and __sl__. If the __locale__ attribute is used it overrides dayLabels, monthLabels, dateFormat, todayBtnTxt,
 firstDayOfWeek and sunHighlight properties from the options.
 
 * new locale data can be added to [this](https://github.com/kekeh/mydatepicker/blob/master/src/my-date-picker/services/my-date-picker.locale.service.ts)

--- a/sampleapp/sample-date-picker-inline/sample-date-picker-inline.ts
+++ b/sampleapp/sample-date-picker-inline/sample-date-picker-inline.ts
@@ -25,7 +25,7 @@ export class SampleDatePickerInline implements OnInit {
     private border: string = 'none';
     private locale:string = '';
 
-    private locales:Array<string> = new Array('en', 'fr', 'ja', 'fi', 'es', 'hu', 'sv', 'nl', 'ru', 'no', 'tr', 'pt-br', 'de', 'it', 'pl', 'my', 'sk', 'sl');
+    private locales:Array<string> = new Array('en', 'fr', 'ja', 'fi', 'es', 'hu', 'sv', 'nl', 'ru', 'no', 'tr', 'pt-br', 'de', 'it', 'it-ch', 'pl', 'my', 'sk', 'sl');
     
     constructor() {}
 

--- a/src/my-date-picker/services/my-date-picker.locale.service.ts
+++ b/src/my-date-picker/services/my-date-picker.locale.service.ts
@@ -35,7 +35,7 @@ export class LocaleService {
             firstDayOfWeek: "mo",
             sunHighlight: true,
         },
-       "es": {
+        "es": {
             dayLabels: {su: "Do", mo: "Lu", tu: "Ma", we: "Mi", th: "Ju", fr: "Vi", sa: "Sa"},
             monthLabels: {1: "Ene", 2: "Feb", 3: "Mar", 4: "Abr", 5: "May", 6: "Jun", 7: "Jul", 8: "Ago", 9: "Sep", 10: "Oct", 11: "Nov", 12: "Dic"},
             dateFormat: "dd.mm.yyyy",
@@ -43,7 +43,7 @@ export class LocaleService {
             firstDayOfWeek: "mo",
             sunHighlight: true,
         },
-       "hu": {
+        "hu": {
             dayLabels: {su: "Vas", mo: "Hét", tu: "Kedd", we: "Sze", th: "Csü", fr: "Pén", sa: "Szo"},
             monthLabels: { 1: "Jan", 2: "Feb", 3: "Már", 4: "Ápr", 5: "Máj", 6: "Jún", 7: "Júl", 8: "Aug", 9: "Szep", 10: "Okt", 11: "Nov", 12: "Dec" },
             dateFormat: "yyyy-mm-dd",

--- a/src/my-date-picker/services/my-date-picker.locale.service.ts
+++ b/src/my-date-picker/services/my-date-picker.locale.service.ts
@@ -110,7 +110,7 @@ export class LocaleService {
         "it": {
             dayLabels: { su: "Dom", mo: "Lun", tu: "Mar", we: "Mer", th: "Gio", fr: "Ven", sa: "Sab" },
             monthLabels: { 1: "Gen", 2: "Feb", 3: "Mar", 4: "Apr", 5: "Mag", 6: "Giu", 7: "Lug", 8: "Ago", 9: "Set", 10: "Ott", 11: "Nov", 12: "Dic" },
-            dateFormat: "dd.mm.yyyy",
+            dateFormat: "dd/mm/yyyy",
             todayBtnTxt: "Oggi",
             firstDayOfWeek: "mo",
             sunHighlight: true

--- a/src/my-date-picker/services/my-date-picker.locale.service.ts
+++ b/src/my-date-picker/services/my-date-picker.locale.service.ts
@@ -115,6 +115,14 @@ export class LocaleService {
             firstDayOfWeek: "mo",
             sunHighlight: true
         },
+        "it-ch": {
+            dayLabels: { su: "Dom", mo: "Lun", tu: "Mar", we: "Mer", th: "Gio", fr: "Ven", sa: "Sab" },
+            monthLabels: { 1: "Gen", 2: "Feb", 3: "Mar", 4: "Apr", 5: "Mag", 6: "Giu", 7: "Lug", 8: "Ago", 9: "Set", 10: "Ott", 11: "Nov", 12: "Dic" },
+            dateFormat: "dd.mm.yyyy",
+            todayBtnTxt: "Oggi",
+            firstDayOfWeek: "mo",
+            sunHighlight: true
+        },
         "pl": {
             dayLabels: { su: "Nie", mo: "Pon", tu: "Wto", we: "Śro", th: "Czw", fr: "Pią", sa: "Sob" },
             monthLabels: { 1: "Sty", 2: "Lut", 3: "Mar", 4: "Kwi", 5: "Maj", 6: "Cze", 7: "Lip", 8: "Sie", 9: "Wrz", 10: "Paź", 11: "Lis", 12: "Gru" },


### PR DESCRIPTION
1. Update italian date format to most common separator, see e.g. [wikipedia](https://en.wikipedia.org/wiki/Date_format_by_country#Listing).
1. Add Switzerland italian locale