### PR TITLE
Added NumericDateDirective

### DIFF
--- a/src/my-date-picker/directives/my-date-picker.numeric.directive.ts
+++ b/src/my-date-picker/directives/my-date-picker.numeric.directive.ts
@@ -1,0 +1,25 @@
+import { Directive, ElementRef, HostListener, Input } from "@angular/core";
+
+@Directive({
+    selector: "[myinputnumeric]"
+})
+export class NumericDateDirective {
+    private regexStr = "^[0-9/.-]*$";
+    private allowedKeys: Array<string> = ["Backspace", "Tab", "End", "Home", "ArrowLeft", "ArrowRight"];
+    constructor(private element: ElementRef) {       
+    }
+    @HostListener("keydown", ["$event"]) onKeyDown(event: KeyboardEvent) {
+        if (this.allowedKeys.indexOf(event.key) !== -1) {
+            return;
+        }
+        let current: string = this.element.nativeElement.value;
+        let next: string = current.concat(event.key);
+        let regEx = new RegExp(this.regexStr);
+        if (regEx.test(next)) {
+            return;
+        }
+        else {
+            event.preventDefault();
+        }
+    }
+}

--- a/src/my-date-picker/my-date-picker.component.html
+++ b/src/my-date-picker/my-date-picker.component.html
@@ -1,7 +1,7 @@
 <div class="mydp" [ngStyle]="{'width': getComponentWidth(), 'border': opts.inline ? 'none' : null}">
     <div class="selectiongroup" *ngIf="!opts.inline">
         <input *ngIf="opts.showInputField" ngtype="text" class="selection" [attr.aria-label]="opts.ariaLabelInputField" [attr.maxlength]="opts.dateFormat.length" [ngClass]="{'invaliddate': invalidDate&&opts.indicateInvalidDate}" placeholder="{{placeholder}}"
-                [myinputautofill]="autoFillOpts" [ngStyle]="{'height': opts.height, 'line-height': opts.height, 'font-size': opts.selectionTxtFontSize, 'border': 'none', 'padding-right': selectionDayTxt.length>0&&opts.showClearDateBtn ? '60px' : '30px'}"
+                myinputnumeric [myinputautofill]="autoFillOpts" [ngStyle]="{'height': opts.height, 'line-height': opts.height, 'font-size': opts.selectionTxtFontSize, 'border': 'none', 'padding-right': selectionDayTxt.length>0&&opts.showClearDateBtn ? '60px' : '30px'}"
                 (keyup)="userDateInput($event)" [value]="selectionDayTxt" (blur)="lostFocusInput($event)" [disabled]="opts.componentDisabled" [readonly]="!opts.editableDateField" [required]="opts.inputValueRequired" (click)="handleInputClick($event)">
         <div class="selbtngroup" [style.height]="opts.height">
             <button type="button" [attr.aria-label]="opts.ariaLabelClearDate" class="btnclear" *ngIf="selectionDayTxt.length>0&&opts.showClearDateBtn" (click)="removeBtnClicked()" [ngClass]="{'btnclearenabled': !opts.componentDisabled, 'btncleardisabled': opts.componentDisabled, 'btnleftborder': opts.showInputField}" [disabled]="opts.componentDisabled">

--- a/src/my-date-picker/my-date-picker.module.ts
+++ b/src/my-date-picker/my-date-picker.module.ts
@@ -4,11 +4,12 @@ import { NgModule } from "@angular/core";
 import { MyDatePicker } from "./my-date-picker.component";
 import { FocusDirective } from "./directives/my-date-picker.focus.directive";
 import { InputAutoFillDirective } from "./directives/my-date-picker.input.auto.fill.directive";
+import { NumericDateDirective } from "./directives/my-date-picker.numeric.directive";
 
 @NgModule({
     imports: [CommonModule, FormsModule],
-    declarations: [MyDatePicker, FocusDirective, InputAutoFillDirective],
-    exports: [MyDatePicker, FocusDirective, InputAutoFillDirective]
+    declarations: [MyDatePicker, FocusDirective, InputAutoFillDirective, NumericDateDirective],
+    exports: [MyDatePicker, FocusDirective, InputAutoFillDirective, NumericDateDirective]
 })
 export class MyDatePickerModule {
 }


### PR DESCRIPTION
I added NumericDateDirective to make the text box for dates accept numbers (0-9), slash (/), period (.), and dash (-) for the date separator. Without the directive, it would accept any keyed value.

Signed-off-by: Chuck B <chuck@chuckbeasley.com>