### PR TITLE
Add locale for Australia

### DIFF
--- a/src/my-date-picker/services/my-date-picker.locale.service.ts
+++ b/src/my-date-picker/services/my-date-picker.locale.service.ts
@@ -202,7 +202,15 @@ export class LocaleService {
             todayBtnTxt: "Hari ini",
             firstDayOfWeek: "su",
             sunHighlight: true
-        }
+        },
+        "en-au": {
+            dayLabels: {su: "Sun", mo: "Mon", tu: "Tue", we: "Wed", th: "Thu", fr: "Fri", sa: "Sat"},
+            monthLabels: { 1: "Jan", 2: "Feb", 3: "Mar", 4: "Apr", 5: "May", 6: "Jun", 7: "Jul", 8: "Aug", 9: "Sep", 10: "Oct", 11: "Nov", 12: "Dec" },
+            dateFormat: "dd/mm/yyyy",
+            todayBtnTxt: "Today",
+            firstDayOfWeek: "mo",
+            sunHighlight: true,
+        },        
     };
 
     getLocaleOptions(locale: string): IMyOptions {

--- a/src/my-date-picker/services/my-date-picker.locale.service.ts
+++ b/src/my-date-picker/services/my-date-picker.locale.service.ts
@@ -210,7 +210,7 @@ export class LocaleService {
             todayBtnTxt: "Today",
             firstDayOfWeek: "mo",
             sunHighlight: true,
-        },        
+        }        
     };
 
     getLocaleOptions(locale: string): IMyOptions {


### PR DESCRIPTION
Add a locale for Australia (english).

Key difference is date format is dd/mm/yyyy.