### PR TITLE
Add date decrease and increase buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ Value of the __options__ attribute is a type of [IMyOptions](https://github.com/
 | __showWeekNumbers__   | false | boolean | Are week numbers visible or not on calendar. Can be used if __firstDayOfWeek = mo__. |
 | __inline__   | false | boolean | Show mydatepicker in inline mode. |
 | __showClearDateBtn__   | true | boolean | Is clear date button shown or not. Can be used if __inline = false__. |
+| __showDecreaseDateBtn__   | false | boolean | Is decrease date button shown or not. Can be used if __inline = false__. |
+| __showIncreaseDateBtn__   | false | boolean | Is increase date button shown or not. Can be used if __inline = false__. |
 | __height__   | 34px | string | mydatepicker height in without selector. Can be used if __inline = false__. |
 | __width__   | 100% | string | mydatepicker width. Can be used if __inline = false__. |
 | __selectionTxtFontSize__   | 14px | string | Selection area font size. Can be used if __inline = false__. |
@@ -232,6 +234,8 @@ Value of the __options__ attribute is a type of [IMyOptions](https://github.com/
 | __openSelectorOnInputClick__   | false | boolean | Open selector when the input field is clicked. Can be used if __inline = false and editableDateField = false__. |
 | __ariaLabelInputField__   | Date input field | string | Aria label text of input field. |
 | __ariaLabelClearDate__   | Clear Date | string | Aria label text of clear date button. |
+| __ariaLabelDecreaseDate__   | Decrease Date | string | Aria label text of decrease date button. |
+| __ariaLabelIncreaseDate__   | Increase Date | string | Aria label text of increase date button. |
 | __ariaLabelOpenCalendar__   | Open Calendar | string | Aria label text of open calendar button. |
 | __ariaLabelPrevMonth__   | Previous Month | string | Aria label text of previous month button. |
 | __ariaLabelNextMonth__   | Next Month | string | Aria label text of next month button. |

--- a/sampleapp/sample-date-picker-normal/sample-date-picker-normal.html
+++ b/sampleapp/sample-date-picker-normal/sample-date-picker-normal.html
@@ -26,6 +26,18 @@
         </li>
         <li>
             <label>
+                <span>Show decrease date button:</span>
+                <input style="cursor: pointer" type="checkbox" (change)="onShowDecreaseDateButton($event.currentTarget.checked)" [checked]="false">
+            </label>
+        </li>
+        <li>
+            <label>
+                <span>Show increase date button:</span>
+                <input style="cursor: pointer" type="checkbox" (change)="onShowIncreaseDateButton($event.currentTarget.checked)" [checked]="false">
+            </label>
+        </li>
+        <li>
+            <label>
                 <span>Show input field:</span>
                 <input style="cursor: pointer" type="checkbox" (change)="onShowInputField($event.currentTarget.checked)" [checked]="true">
             </label>

--- a/sampleapp/sample-date-picker-normal/sample-date-picker-normal.ts
+++ b/sampleapp/sample-date-picker-normal/sample-date-picker-normal.ts
@@ -31,6 +31,8 @@ export class SampleDatePickerNormal implements OnInit {
         maxYear: 2200,
         componentDisabled: false,
         showClearDateBtn: true,
+        showDecreaseDateBtn: false,
+        showIncreaseDateBtn: false,
         showSelectorArrow: true,
         showInputField: true,
         openSelectorOnInputClick: false,
@@ -67,6 +69,14 @@ export class SampleDatePickerNormal implements OnInit {
         this.selectedDateNormal = '';
     }
 
+    decreaseDate() {
+        this.selectedDateNormal = '';
+    }
+
+    increaseDate() {
+        this.selectedDateNormal = '';
+    }
+
     onDisableComponent(checked: boolean) {
         this.disabled = checked;
     }
@@ -87,6 +97,18 @@ export class SampleDatePickerNormal implements OnInit {
     onShowClearDateButton(checked: boolean) {
         let copy = this.getCopyOfOptions();
         copy.showClearDateBtn = checked;
+        this.myDatePickerNormalOptions = copy;
+    }
+
+    onShowDecreaseDateButton(checked: boolean) {
+        let copy = this.getCopyOfOptions();
+        copy.showDecreaseDateBtn = checked;
+        this.myDatePickerNormalOptions = copy;
+    }
+
+    onShowIncreaseDateButton(checked: boolean) {
+        let copy = this.getCopyOfOptions();
+        copy.showIncreaseDateBtn = checked;
         this.myDatePickerNormalOptions = copy;
     }
 

--- a/src/my-date-picker/interfaces/my-options.interface.ts
+++ b/src/my-date-picker/interfaces/my-options.interface.ts
@@ -45,6 +45,8 @@ export interface IMyOptions {
     openSelectorOnInputClick?: boolean;
     ariaLabelInputField?: string;
     ariaLabelClearDate?: string;
+    ariaLabelDecreaseDate?: string;
+    ariaLabelIncreaseDate?: string;
     ariaLabelOpenCalendar?: string;
     ariaLabelPrevMonth?: string;
     ariaLabelNextMonth?: string;

--- a/src/my-date-picker/interfaces/my-options.interface.ts
+++ b/src/my-date-picker/interfaces/my-options.interface.ts
@@ -28,6 +28,8 @@ export interface IMyOptions {
     selectionTxtFontSize?: string;
     inline?: boolean;
     showClearDateBtn?: boolean;
+    showDecreaseDateBtn?: boolean;
+    showIncreaseDateBtn?: boolean;
     alignSelectorRight?: boolean;
     openSelectorTopOfInput?: boolean;
     indicateInvalidDate?: boolean;

--- a/src/my-date-picker/my-date-picker.component.css
+++ b/src/my-date-picker/my-date-picker.component.css
@@ -52,6 +52,11 @@
     border-bottom-left-radius: 4px;
 }
 
+.mydp .btnrightborderradius {
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+}
+
 .mydp .selector {
     margin-top: 2px;
     margin-left: -1px;
@@ -138,7 +143,6 @@
     background-color: #FFF;
     display: table-cell;
     position: absolute;
-    width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -165,7 +169,9 @@
 }
 
 .mydp .btnpicker,
-.mydp .btnclear {
+.mydp .btnclear,
+.mydp .btndecrease,
+.mydp .btnincrease {
     height: 100%;
     width: 28px;
     border: none;
@@ -179,8 +185,14 @@
     border-left: 1px solid #CCC;
 }
 
+.mydp .btnrightborder {
+    border-right: 1px solid #CCC;
+}
+
 .mydp .btnpickerenabled,
 .mydp .btnclearenabled,
+.mydp .btndecreaseenabled,
+.mydp .btnincreaseenabled,
 .mydp .headertodaybtnenabled,
 .mydp .headerbtnenabled,
 .mydp .yearchangebtnenabled {
@@ -190,6 +202,8 @@
 .mydp .selectiondisabled,
 .mydp .btnpickerdisabled,
 .mydp .btncleardisabled,
+.mydp .btndecreasedisabled,
+.mydp .btnincreasedisabled,
 .mydp .headertodaybtndisabled,
 .mydp .headerbtndisabled,
 .mydp .yearchangebtndisabled {
@@ -203,6 +217,8 @@
 
 .mydp .btnpicker,
 .mydp .btnclear,
+.mydp .btndecrease,
+.mydp .btnincrease,
 .mydp .headertodaybtn {
     background: #FFF;
 }
@@ -401,6 +417,8 @@
 
 .mydp .btnpicker,
 .mydp .btnclear,
+.mydp .btndecrease,
+.mydp .btnincrease,
 .mydp .headerbtn,
 .mydp .headermonthtxt,
 .mydp .headeryeartxt,
@@ -437,6 +455,8 @@
 }
 
 .mydp .btnclear:focus,
+.mydp .btndecrease:focus,
+.mydp .btnincrease:focus,
 .mydp .btnpicker:focus,
 .mydp .headertodaybtn:focus {
     background: #ADD8E6;
@@ -469,6 +489,11 @@
     font-size: 20px;
 }
 
+.mydp .btndecrease .icon-mydpleft,
+.mydp .btnincrease .icon-mydpright {
+    font-size: 16px;
+}
+
 .mydp .icon-mydptoday {
     color: #222;
     font-size: 11px;
@@ -491,6 +516,8 @@
 
 .mydp .btnpickerenabled:hover,
 .mydp .btnclearenabled:hover,
+.mydp .btndecreaseenabled:hover,
+.mydp .btnincreaseenabled:hover,
 .mydp .headertodaybtnenabled:hover {
     background-color: #E6E6E6;
 }
@@ -570,6 +597,3 @@
 .mydp .icon-mydpremove:before {
     content: "\e806";
 }
-
-
-

--- a/src/my-date-picker/my-date-picker.component.html
+++ b/src/my-date-picker/my-date-picker.component.html
@@ -1,11 +1,19 @@
 <div class="mydp" [ngStyle]="{'width': opts.showInputField ? opts.width : null, 'border': opts.inline ? 'none' : null}">
     <div class="selectiongroup" *ngIf="!opts.inline">
+        <div class="selbtngroup" [style.height]="opts.height">
+          <button type="button" [attr.aria-label]="opts.ariaLabelDecreaseDate" class="btndecrease" *ngIf="opts.showDecreaseDateBtn" (click)="decreaseBtnClicked()" [ngClass]="{'btndecreaseenabled': !opts.componentDisabled, 'btndecreasedisabled': opts.componentDisabled, 'btnrightborder': opts.showInputField, 'btnleftborderradius': !opts.showInputField}" [disabled]="opts.componentDisabled">
+              <span class="mydpicon icon-mydpleft"></span>
+          </button>
+        </div>
         <input *ngIf="opts.showInputField" ngtype="text" class="selection" [attr.aria-label]="opts.ariaLabelInputField" (click)="opts.openSelectorOnInputClick&&!opts.editableDateField&&openBtnClicked()" [ngClass]="{'invaliddate': invalidDate&&opts.indicateInvalidDate, 'inputnoteditable': opts.openSelectorOnInputClick&&!opts.editableDateField, 'selectiondisabled': opts.componentDisabled}"
                 placeholder="{{placeholder}}" [ngStyle]="{'height': opts.height, 'font-size': opts.selectionTxtFontSize}" [ngModel]="selectionDayTxt" (ngModelChange)="onUserDateInput($event)" [value]="selectionDayTxt" (keyup)="onCloseSelector($event)"
                (focus)="opts.editableDateField&&onFocusInput($event)" (blur)="opts.editableDateField&&onBlurInput($event)" [disabled]="opts.componentDisabled" [readonly]="!opts.editableDateField" autocomplete="off">
         <div class="selbtngroup" [style.height]="opts.height">
             <button type="button" [attr.aria-label]="opts.ariaLabelClearDate" class="btnclear" *ngIf="selectionDayTxt.length>0&&opts.showClearDateBtn" (click)="removeBtnClicked()" [ngClass]="{'btnclearenabled': !opts.componentDisabled, 'btncleardisabled': opts.componentDisabled, 'btnleftborder': opts.showInputField, 'btnleftborderradius': !opts.showInputField}" [disabled]="opts.componentDisabled">
                 <span class="mydpicon icon-mydpremove"></span>
+            </button>
+            <button type="button" [attr.aria-label]="opts.ariaLabelIncreaseDate" class="btnincrease" *ngIf="opts.showIncreaseDateBtn" (click)="increaseBtnClicked()" [ngClass]="{'btnincreaseenabled': !opts.componentDisabled, 'btnincreasedisabled': opts.componentDisabled, 'btnleftborder': opts.showInputField, 'btnleftborderradius': !opts.showInputField}" [disabled]="opts.componentDisabled">
+                <span class="mydpicon icon-mydpright"></span>
             </button>
             <button type="button" [attr.aria-label]="opts.ariaLabelOpenCalendar" class="btnpicker" (click)="openBtnClicked()" [ngClass]="{'btnpickerenabled': !opts.componentDisabled, 'btnpickerdisabled': opts.componentDisabled, 'btnleftborder': opts.showInputField||selectionDayTxt.length>0&&opts.showClearDateBtn, 'btnleftborderradius': !opts.showClearDateBtn&&!opts.showInputField||!opts.showInputField&&selectionDayTxt.length===0}" [disabled]="opts.componentDisabled">
                 <span class="mydpicon icon-mydpcalendar"></span>

--- a/src/my-date-picker/my-date-picker.component.spec.ts
+++ b/src/my-date-picker/my-date-picker.component.spec.ts
@@ -1350,6 +1350,120 @@ describe('MyDatePicker', () => {
         expect(btnclear).toBe(null);
     });
 
+    it('options - show decrease date button', () => {
+        let date = new Date();
+        comp.selectedMonth = {monthTxt: '', monthNbr: date.getMonth() + 1, year: date.getFullYear()};
+
+        fixture.detectChanges();
+        let btnpicker = getElement('.btnpicker');
+        btnpicker.nativeElement.click();
+
+        fixture.detectChanges();
+        let currday = getElement('.currday');
+        expect(currday).not.toBe(null);
+
+        currday.nativeElement.click();
+
+        fixture.detectChanges();
+        let btndecrease = getElement('.btndecrease');
+        expect(btndecrease).toBe(null);
+
+        comp.options = {showDecreaseDateBtn: true};
+        comp.parseOptions();
+
+        fixture.detectChanges();
+        btnpicker = getElement('.btnpicker');
+        btnpicker.nativeElement.click();
+
+        fixture.detectChanges();
+        currday = getElement('.currday');
+        expect(currday).not.toBe(null);
+
+        currday.nativeElement.click();
+
+        fixture.detectChanges();
+        btndecrease = getElement('.btndecrease');
+        expect(btndecrease).not.toBe(null);
+        btndecrease.nativeElement.click();
+
+        btndecrease.nativeElement.click();
+
+
+        comp.options = {showDecreaseDateBtn: false};
+        comp.parseOptions();
+
+        fixture.detectChanges();
+        btnpicker = getElement('.btnpicker');
+        btnpicker.nativeElement.click();
+
+        fixture.detectChanges();
+        currday = getElement('.currday');
+        expect(currday).not.toBe(null);
+
+        currday.nativeElement.click();
+
+        fixture.detectChanges();
+        btndecrease = getElement('.btndecrease');
+        expect(btndecrease).toBe(null);
+    });
+
+    it('options - show increase date button', () => {
+        let date = new Date();
+        comp.selectedMonth = {monthTxt: '', monthNbr: date.getMonth() + 1, year: date.getFullYear()};
+
+        fixture.detectChanges();
+        let btnpicker = getElement('.btnpicker');
+        btnpicker.nativeElement.click();
+
+        fixture.detectChanges();
+        let currday = getElement('.currday');
+        expect(currday).not.toBe(null);
+
+        currday.nativeElement.click();
+
+        fixture.detectChanges();
+        let btnincrease = getElement('.btnincrease');
+        expect(btnincrease).toBe(null);
+
+        comp.options = {showIncreaseDateBtn: true};
+        comp.parseOptions();
+
+        fixture.detectChanges();
+        btnpicker = getElement('.btnpicker');
+        btnpicker.nativeElement.click();
+
+        fixture.detectChanges();
+        currday = getElement('.currday');
+        expect(currday).not.toBe(null);
+
+        currday.nativeElement.click();
+
+        fixture.detectChanges();
+        btnincrease = getElement('.btnincrease');
+        expect(btnincrease).not.toBe(null);
+        btnincrease.nativeElement.click();
+
+        btnincrease.nativeElement.click();
+
+
+        comp.options = {showIncreaseDateBtn: false};
+        comp.parseOptions();
+
+        fixture.detectChanges();
+        btnpicker = getElement('.btnpicker');
+        btnpicker.nativeElement.click();
+
+        fixture.detectChanges();
+        currday = getElement('.currday');
+        expect(currday).not.toBe(null);
+
+        currday.nativeElement.click();
+
+        fixture.detectChanges();
+        btnincrease = getElement('.btnincrease');
+        expect(btnincrease).toBe(null);
+    });
+
     it('options - height', () => {
         comp.selectedMonth = {monthTxt: '', monthNbr: 10, year: 2016};
         comp.options = {height: '50px'};
@@ -1485,16 +1599,16 @@ describe('MyDatePicker', () => {
         invaliddate = getElement('.invaliddate');
         expect(invaliddate).toBe(null);
     });
-    
+
     it('options - disableUntil input dates validation', ()=> {
         comp.options = {
-            indicateInvalidDate: true, 
-            dateFormat: 'dd.mm.yyyy', 
+            indicateInvalidDate: true,
+            dateFormat: 'dd.mm.yyyy',
             disableUntil:{year: 2016, month: 11, day: 4}
         };
-        
+
         comp.parseOptions();
-        
+
         comp.onUserDateInput('11.12.2015');
         fixture.detectChanges();
         let invaliddate = getElement('.invaliddate');
@@ -1891,6 +2005,7 @@ describe('MyDatePicker', () => {
 
     it('options - aria label texts', () => {
         comp.selectedDate = comp.parseSelectedDate('2017-10-11');
+        comp.options = {showDecreaseDateBtn: true, showIncreaseDateBtn: true};
         comp.parseOptions();
 
         fixture.detectChanges();
@@ -1910,6 +2025,15 @@ describe('MyDatePicker', () => {
         expect(btnclear).not.toBe(null);
         expect(btnclear.nativeElement.attributes['aria-label'].textContent).toBe('Clear Date');
 
+        fixture.detectChanges();
+        let btndecrease = getElement('.btndecrease');
+        expect(btndecrease).not.toBe(null);
+        expect(btndecrease.nativeElement.attributes['aria-label'].textContent).toBe('Decrease Date');
+
+        fixture.detectChanges();
+        let btnincrease = getElement('.btnincrease');
+        expect(btnincrease).not.toBe(null);
+        expect(btnincrease.nativeElement.attributes['aria-label'].textContent).toBe('Increase Date');
 
         fixture.detectChanges();
         let prevmonth = getElement(PREVMONTH);
@@ -1936,11 +2060,13 @@ describe('MyDatePicker', () => {
         comp.options = {
             ariaLabelInputField: 'text 1',
             ariaLabelClearDate: 'text 2',
-            ariaLabelOpenCalendar: 'text 3',
-            ariaLabelPrevMonth: 'text 4',
-            ariaLabelNextMonth: 'text 5',
-            ariaLabelPrevYear: 'text 6',
-            ariaLabelNextYear: 'text 7'
+            ariaLabelDecreaseDate: 'text 3',
+            ariaLabelIncreaseDate: 'text 4',
+            ariaLabelOpenCalendar: 'text 5',
+            ariaLabelPrevMonth: 'text 6',
+            ariaLabelNextMonth: 'text 7',
+            ariaLabelPrevYear: 'text 8',
+            ariaLabelNextYear: 'text 9'
         };
         comp.parseOptions();
 
@@ -1961,6 +2087,15 @@ describe('MyDatePicker', () => {
         expect(btnclear).not.toBe(null);
         expect(btnclear.nativeElement.attributes['aria-label'].textContent).toBe(comp.options.ariaLabelClearDate);
 
+        fixture.detectChanges();
+        btndecrease = getElement('.btndecrease');
+        expect(btndecrease).not.toBe(null);
+        expect(btndecrease.nativeElement.attributes['aria-label'].textContent).toBe(comp.options.ariaLabelDecreaseDate);
+
+        fixture.detectChanges();
+        btnincrease = getElement('.btnincrease');
+        expect(btnincrease).not.toBe(null);
+        expect(btnincrease.nativeElement.attributes['aria-label'].textContent).toBe(comp.options.ariaLabelIncreaseDate);
 
         fixture.detectChanges();
         prevmonth = getElement(PREVMONTH);
@@ -2340,8 +2475,3 @@ describe('MyDatePicker', () => {
     });
 
 });
-
-
-
-
-

--- a/src/my-date-picker/my-date-picker.component.ts
+++ b/src/my-date-picker/my-date-picker.component.ts
@@ -106,6 +106,8 @@ export class MyDatePicker implements OnChanges, ControlValueAccessor {
         selectionTxtFontSize: <string> "14px",
         inline: <boolean> false,
         showClearDateBtn: <boolean> true,
+        showDecreaseDateBtn: <boolean> false,
+        showIncreaseDateBtn: <boolean> false,
         alignSelectorRight: <boolean> false,
         openSelectorTopOfInput: <boolean> false,
         indicateInvalidDate: <boolean> true,

--- a/src/my-date-picker/my-date-picker.component.ts
+++ b/src/my-date-picker/my-date-picker.component.ts
@@ -123,6 +123,8 @@ export class MyDatePicker implements OnChanges, ControlValueAccessor {
         openSelectorOnInputClick: <boolean> false,
         ariaLabelInputField: <string> "Date input field",
         ariaLabelClearDate: <string> "Clear Date",
+        ariaLabelDecreaseDate: <string> "Decrease Date",
+        ariaLabelIncreaseDate: <string> "Increase Date",
         ariaLabelOpenCalendar: <string> "Open Calendar",
         ariaLabelPrevMonth: <string> "Previous Month",
         ariaLabelNextMonth: <string> "Next Month",
@@ -404,6 +406,24 @@ export class MyDatePicker implements OnChanges, ControlValueAccessor {
         this.showSelector = false;
     }
 
+    decreaseBtnClicked(): void {
+        // Decrease date button clicked
+        this.decreaseDate();
+        if (this.showSelector) {
+            this.calendarToggle.emit(CalToggle.CloseByCalBtn);
+        }
+        this.showSelector = false;
+    }
+
+    increaseBtnClicked(): void {
+        // Increase date button clicked
+        this.increaseDate();
+        if (this.showSelector) {
+            this.calendarToggle.emit(CalToggle.CloseByCalBtn);
+        }
+        this.showSelector = false;
+    }
+
     openBtnClicked(): void {
         // Open selector button clicked
         this.showSelector = !this.showSelector;
@@ -523,6 +543,50 @@ export class MyDatePicker implements OnChanges, ControlValueAccessor {
         this.onChangeCb("");
         this.onTouchedCb();
         this.updateDateValue(date, true);
+    }
+
+    decreaseDate(): void {
+      // Decreases the date and notifies parent using callbacks and value accessor
+      let date = this.selectedDate;
+      if (date.day !== 0 && date.month !== 0 && date.year !== 0) {
+        let advancedDate = this.getDate(this.selectedDate.year, this.selectedDate.month, this.selectedDate.day);
+        advancedDate.setDate(advancedDate.getDate() - 1);
+        date = {year: advancedDate.getFullYear(), month: advancedDate.getMonth() + 1, day: advancedDate.getDate()};;
+      } else {
+        date = this.getToday();
+      }
+
+      let dateModel: IMyDateModel = this.getDateModel(date);
+      this.dateChanged.emit(dateModel);
+      this.onChangeCb(dateModel);
+      this.onTouchedCb();
+      this.updateDateValue(date, false);
+      if (this.showSelector) {
+          this.calendarToggle.emit(CalToggle.CloseByDateSel);
+      }
+      this.showSelector = false;
+    }
+
+    increaseDate(): void {
+        // Increases the date and notifies parent using callbacks and value accessor
+        let date = this.selectedDate;
+        if (date.day !== 0 && date.month !== 0 && date.year !== 0) {
+          let advancedDate = this.getDate(this.selectedDate.year, this.selectedDate.month, this.selectedDate.day);
+          advancedDate.setDate(advancedDate.getDate() + 1);
+          date = {year: advancedDate.getFullYear(), month: advancedDate.getMonth() + 1, day: advancedDate.getDate()};;
+        } else {
+          date = this.getToday();
+        }
+
+        let dateModel: IMyDateModel = this.getDateModel(date);
+        this.dateChanged.emit(dateModel);
+        this.onChangeCb(dateModel);
+        this.onTouchedCb();
+        this.updateDateValue(date, false);
+        if (this.showSelector) {
+            this.calendarToggle.emit(CalToggle.CloseByDateSel);
+        }
+        this.showSelector = false;
     }
 
     selectDate(date: IMyDate): void {


### PR DESCRIPTION
This adds buttons to increase and decrease the set date by one day. If a date is not set, both buttons will set the date to the current day.

By default, both the decrease and increase buttons are hidden.