### PR TITLE
on edit input date field  0 is added automaticlly,  if single digit  …

### DIFF
--- a/sampleapp/sample-date-picker-normal/sample-date-picker-normal.ts
+++ b/sampleapp/sample-date-picker-normal/sample-date-picker-normal.ts
@@ -16,7 +16,7 @@ export class SampleDatePickerNormal implements OnInit {
 
     private myDatePickerNormalOptions: IMyDpOptions = {
         todayBtnTxt: 'Today',
-        dateFormat: 'mmm dd, yyyy',
+        dateFormat: 'mm/dd/yyyy',
         firstDayOfWeek: 'mo',
         sunHighlight: true,
         markCurrentDay: true,

--- a/src/my-date-picker/services/my-date-picker.util.service.ts
+++ b/src/my-date-picker/services/my-date-picker.util.service.ts
@@ -15,6 +15,12 @@ const YYYY = "yyyy";
 @Injectable()
 export class UtilService {
     isDateValid(dateStr: string, dateFormat: string, minYear: number, maxYear: number, disableUntil: IMyDate, disableSince: IMyDate, disableWeekends: boolean, disableDays: Array<IMyDate>, disableDateRanges: Array<IMyDateRange>, monthLabels: IMyMonthLabels, enableDays: Array<IMyDate>): IMyDate {
+        // added this code to add extra  0 for single digit month or day only please refactore if needed.
+        let dateValue = dateStr.split( "/" );
+        dateValue[0] = dateValue[0].length < 2 ? "0" + dateValue[0] :  dateValue[0];
+        dateValue[1] = dateValue[0].length < 2 ? "0" + dateValue[0] :  dateValue[0];
+        dateStr = dateValue[0] + "/" + dateValue[1] + "/" + dateValue[2];
+        // code end
         let returnDate: IMyDate = {day: 0, month: 0, year: 0};
         let daysInMonth: Array<number> = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
         let isMonthStr: boolean = dateFormat.indexOf(MMM) !== -1;


### PR DESCRIPTION
when i add date manually in datepicker for ex : 1/1/2017 then it becomes invalid. because it works with 01/01/2017.  so i want 1/1/2017 to become valid .  so i updated for "/" separator. 
PrimeNg is working like the way i want but i dont want use that. so i updated this datepicker to work for me. 
please check , verify and  update as you like.