### PR TITLE
Update my-date-picker.locale.service.ts

### DIFF
--- a/src/my-date-picker/services/my-date-picker.locale.service.ts
+++ b/src/my-date-picker/services/my-date-picker.locale.service.ts
@@ -7,7 +7,7 @@ export class LocaleService {
         "en": {
             dayLabels: {su: "Sun", mo: "Mon", tu: "Tue", we: "Wed", th: "Thu", fr: "Fri", sa: "Sat"},
             monthLabels: { 1: "Jan", 2: "Feb", 3: "Mar", 4: "Apr", 5: "May", 6: "Jun", 7: "Jul", 8: "Aug", 9: "Sep", 10: "Oct", 11: "Nov", 12: "Dec" },
-            dateFormat: "yyyy-mm-dd",
+            dateFormat: "mm/dd/yyyy",
             todayBtnTxt: "Today",
             firstDayOfWeek: "mo",
             sunHighlight: true,


### PR DESCRIPTION
Sticking to the default Javascript `Date` prototype, running `new Date(Date.UTC(2012, 11, 20, 3, 0, 0)).toLocaleString('en');` for example produces `12/19/2012`