### PR TITLE
Prevent re-setting of selected date if it is already selected on input

### DIFF
--- a/src/my-date-picker/my-date-picker.component.spec.ts
+++ b/src/my-date-picker/my-date-picker.component.spec.ts
@@ -2693,4 +2693,21 @@ describe('MyDatePicker', () => {
         expect(invaliddate).toBe(null);
     });
 
+
+    it('"selects" the date if the selected date is not the same as the input date on input changed and the input date is valid', () => {
+        spyOn(comp, 'selectDate');
+        comp.selectedDate = { day: 31, month: 8, year: 2017 };
+        comp.options = { dateFormat: 'dd-mm-yyyy' }
+        comp.setOptions();
+
+        comp.onUserDateInput('31-08-2017'); // Already selected input
+        expect(comp.selectDate).not.toHaveBeenCalled();
+
+        comp.onUserDateInput('0-10-2017'); // Invalid input
+        expect(comp.selectDate).not.toHaveBeenCalled();
+
+        comp.onUserDateInput('01-10-2017'); // Different date
+        expect(comp.selectDate).toHaveBeenCalled();
+    });
+
 });

--- a/src/my-date-picker/my-date-picker.component.ts
+++ b/src/my-date-picker/my-date-picker.component.ts
@@ -287,7 +287,9 @@ export class MyDatePicker implements OnChanges, ControlValueAccessor {
         else {
             let date: IMyDate = this.utilService.isDateValid(value, this.opts.dateFormat, this.opts.minYear, this.opts.maxYear, this.opts.disableUntil, this.opts.disableSince, this.opts.disableWeekends, this.opts.disableWeekdays, this.opts.disableDays, this.opts.disableDateRanges, this.opts.monthLabels, this.opts.enableDays);
             if (date.day !== 0 && date.month !== 0 && date.year !== 0) {
-                this.selectDate(date, CalToggle.CloseByDateSel);
+                if (!this.selectedDate || this.selectedDate.day !== date.day || this.selectedDate.month !== date.month || this.selectedDate.year !== date.year) {
+                    this.selectDate(date, CalToggle.CloseByDateSel);
+                }
             }
             else {
                 this.invalidInputFieldChanged(value);


### PR DESCRIPTION
We had a problem using the picker in IE9 (yes, yes I know) when combined with buzinas's [IE9 oninput polyfill](https://github.com/buzinas/ie9-oninput-polyfill).

The polyfill fires an 'input' event from an element when the selected element changes, because IE9 doesn't fire this event on delete/cut (as we need it to). 


The problem being: 

```onUserDateInput``` calls ```selectDate``` which calls ```setFocusToInputBox``` -> ```nativeElement.focus```. This fires ```document.selectionchange```, which is picked up by the polyfill. The polyfill fires the ```input``` event on the element, which is picked up by ```onUserDateInput``` and an infinite loop ensued. 

Comparing the input date against the currently selected date allows the call to ```selectDate``` to be avoided, which fixes our problems with (seemingly) no ill effects.