### PR TITLE
Increased min and max year limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ Value of the __options__ attribute is a type of [IMyDpOptions](https://github.co
 | __markCurrentYear__   | true | boolean | Is current year marked on calendar. Can be used if __yearSelector = true__. |
 | __monthSelector__  | true | boolean | If month label is selected opens a selector of months. |
 | __yearSelector__  | true | boolean | If year label is selected opens a selector of years. |
-| __minYear__   | 1100 | number | Minimum allowed year in calendar. Cannot be less than 1100. |
-| __maxYear__   | 9100 | number | Maximum allowed year in calendar. Cannot be more than 9100. |
+| __minYear__   | 1000 | number | Minimum allowed year in calendar. Cannot be less than 1000. |
+| __maxYear__   | 9999 | number | Maximum allowed year in calendar. Cannot be more than 9999. |
 | __disableUntil__   | no default value | [IMyDate](https://github.com/kekeh/mydatepicker/blob/master/src/my-date-picker/interfaces/my-date.interface.ts) | Disable dates backward starting from the given date. For example: {year: 2016, month: 6, day: 26}. To reset existing disableUntil value set: {year: 0, month: 0, day: 0} |
 | __disableSince__   | no default value | [IMyDate](https://github.com/kekeh/mydatepicker/blob/master/src/my-date-picker/interfaces/my-date.interface.ts) | Disable dates forward starting from the given date. For example: {year: 2016, month: 7, day: 22}. To reset existing disableSince value set: {year: 0, month: 0, day: 0} |
 | __disableDays__   | no default value  | Array<[IMyDate](https://github.com/kekeh/mydatepicker/blob/master/src/my-date-picker/interfaces/my-date.interface.ts)> | Disable single dates one by one. Array of disabled dates. For example: [{year: 2016, month: 11, day: 14}, {year: 2016, month: 1, day: 15}]. To reset existing disableDays value set empty array to it. |

--- a/src/my-date-picker/my-date-picker.component.ts
+++ b/src/my-date-picker/my-date-picker.component.ts
@@ -17,7 +17,7 @@ export const MYDP_VALUE_ACCESSOR: any = {
 };
 
 enum CalToggle {Open = 1, CloseByDateSel = 2, CloseByCalBtn = 3, CloseByOutClick = 4, CloseByEsc = 5, CloseByApi = 6}
-enum Year {min = 1100, max = 9100}
+enum Year {min = 1000, max = 9999}
 enum InputFocusBlur {focus = 1, blur = 2}
 enum KeyCode {enter = 13, esc = 27, space = 32}
 enum MonthId {prev = 1, curr = 2, next = 3}


### PR DESCRIPTION
Hi,

I understand that the definition of the max and min limit year is subjective but I think that there are other limits with more sense, I would say 1000 and 9999, covering the full 4 digit number range. 

I'm using this calendar with one particular app that uses the 9999 as the max year, so it's also more convenient for me.

Regards.