### PR TITLE
Fix updated date not emitted with value accessor

### DIFF
--- a/src/my-date-picker/my-date-picker.component.ts
+++ b/src/my-date-picker/my-date-picker.component.ts
@@ -626,11 +626,6 @@ export class MyDatePicker implements OnChanges, ControlValueAccessor {
     }
 
     selectDate(date: IMyDate, closeReason: number): void {
-        // Date selected, notifies parent using callbacks and value accessor
-        let dateModel: IMyDateModel = this.getDateModel(date);
-        this.dateChanged.emit(dateModel);
-        this.onChangeCb(dateModel);
-        this.onTouchedCb();
         this.updateDateValue(date, false);
         if (this.showSelector) {
             this.calendarToggle.emit(closeReason);
@@ -651,7 +646,13 @@ export class MyDatePicker implements OnChanges, ControlValueAccessor {
         // Updates date values
         this.selectedDate = date;
         this.selectionDayTxt = clear ? "" : this.formatDate(date);
+
+        let dateModel: IMyDateModel = this.getDateModel(date);
+        this.dateChanged.emit(dateModel);
+        this.onChangeCb(dateModel);
+        this.onTouchedCb();
         this.inputFieldChanged.emit({value: this.selectionDayTxt, dateFormat: this.opts.dateFormat, valid: !clear});
+
         this.invalidDate = false;
     }
 


### PR DESCRIPTION
While using this component in another project, I stumbled upon a small bug when using formControl.

The problem is when you allow free input by users and they input something like this:
`10/28/20178`

The value emitted on the valueChanges observable is of course null. But when the user remove the last 8 (back to a valid date), nothing is emitted.

This problem seems to be introduced with PR #409. MyDatePicker now checks if the new date is different from the last selected date. In the example above, the last valid date is 10/28/2017, so when the user removes the 8, their is no difference so no value is emitted.

In this PR, I moved the calls to emit the values to the updateDateValue. Values will always be emitted if the date is valid and the problem addressed in PR #409 is preserved.