### PR TITLE
Changed evt to event in onClickDocument function 

### DIFF
--- a/src/my-date-picker/my-date-picker.component.ts
+++ b/src/my-date-picker/my-date-picker.component.ts
@@ -492,7 +492,7 @@ export class MyDatePicker implements OnChanges, ControlValueAccessor, OnDestroy 
         document.removeEventListener("click", this.onClickListener);
     }
 
-    onClickDocument(evt: any): void {
+    onClickDocument(event: any): void {
         if (this.showSelector && event.target && this.elem.nativeElement !== event.target && !this.elem.nativeElement.contains(event.target)) {
             this.showSelector = false;
             this.cdr.detectChanges();


### PR DESCRIPTION
#634 
This is with reference to the bug mentioned above.
This is creating bug for me in angular 8 in pollyfills. Getting reference error. By changing this, its working fine.

Changed 
Earlier
 onClickDocument(**evt**: any): void {
        if (this.showSelector && event.target && this.elem.nativeElement !== event.target && !this.elem.nativeElement.contains(event.target)) {
            this.showSelector = false;
........}


NOW:
 onClickDocument(**event**: any): void {
        if (this.showSelector && event.target && this.elem.nativeElement !== event.target && !this.elem.nativeElement.contains(event.target)) {
            this.showSelector = false;
........}